### PR TITLE
Adding `main` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "email": "support@objectivehtml.com",
   "author": "Objective HTML, LLC <support@objectivehtml.com>",
   "license": "MIT",
+  "main": "compiled/flipclock.js",
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
Adding a `main` field so that npm knows what file to include when the package is `require`d.
